### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,12 +5,13 @@
 ###########################################
 # Datatypes (KEYWORD1)
 ###########################################
-SimpleDHT11 SimpleDHT22 KEYWORD1
+SimpleDHT11	KEYWORD1
+SimpleDHT22	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-read KEYWORD2
+read	KEYWORD2
 
 ###########################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords