### PR TITLE
Fix negative temperatures for DHT22

### DIFF
--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -202,7 +202,7 @@ int SimpleDHT22::read2(int pin, float* ptemperature, float* phumidity, byte pdat
         memcpy(pdata, data, 40);
     }
     if (ptemperature) {
-        *ptemperature = (float)temperature / 10.0;
+        *ptemperature = (float)((temperature & 0x8000 ? -1 : 1) * (temperature & 0x7FFF)) / 10.0;
     }
     if (phumidity) {
         *phumidity = (float)humidity / 10.0;


### PR DESCRIPTION
This commit fixes issue https://github.com/winlinvip/SimpleDHT/issues/14
The MSB carries the sign information, which is filtered with `& 0x8000`. If the flag is present, the remainder will get multiplied by `-1`.
All the remaining bits contain the value and are filtered with `& 0x7FFF`.