### PR TITLE
DHT11 sampling fix (tested on ESP8266 and Mega2560 r3)

### DIFF
--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -207,7 +207,7 @@ int SimpleDHT11::sample(byte data[40]) {
     //    1. PULL LOW 80us
     //    2. PULL HIGH 80us
     int t = levelTime( LOW );          // 1.
-    if ( t < 60 ) {                    // specs [2]: 80us
+    if ( t < 38 ) {                    // specs [2]: 80us
         return SimpleDHTErrStartLow;
     }
 

--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -190,7 +190,7 @@ int SimpleDHT11::sample(byte data[40]) {
     //  [2] https://www.mouser.com/ds/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf
     // - original values specified in code
     // - since they were not working (MCU-dependent timing?), replace in code with
-    //   _working_ values based on measurements done with levelTime()
+    //   _working_ values based on measurements done with levelTimePrecise()
     pinMode(pin, OUTPUT);
     digitalWrite(pin, HIGH);
     delay(500);
@@ -206,18 +206,14 @@ int SimpleDHT11::sample(byte data[40]) {
     // DHT11 starting:
     //    1. PULL LOW 80us
     //    2. PULL HIGH 80us
-    int t = levelTime( LOW );     // 1.
-    //if (confirm(pin, 80, LOW)) {
-    if ( t < 60 ) {                      // specs [2]: 80us
+    int t = levelTime( LOW );          // 1.
+    if ( t < 60 ) {                    // specs [2]: 80us
         return SimpleDHTErrStartLow;
-        //return (t == 0 ? 1234 : t);  // DEBUG
     }
 
-    t = levelTime( HIGH );        // 2.
-    //if (confirm(pin, 80, HIGH)) {
+    t = levelTime( HIGH );             // 2.
     if ( t < 70 ) {                    // specs [2]: 80us
         return SimpleDHTErrStartHigh;
-        //return (t == 0 ? 1234 : t);  // DEBUG
     }
 
     // DHT11 data transmite:
@@ -227,27 +223,24 @@ int SimpleDHT11::sample(byte data[40]) {
     //         - 70us, bit(1)
     for (int j = 0; j < 40; j++)
     {
-          t = levelTime( LOW, 10 );     // 1.
-          //if (confirm(pin, 50, LOW)) {
+          t = levelTime( LOW, 10 );          // 1.
           if ( t < 32 ) {                    // specs says: 50us
-              //return SimpleDHTErrDataLow;
-              return (t == 0 ? 1234 : t);  // DEBUG
+              return SimpleDHTErrDataLow;
           }
 
           // read a bit
-	        t = levelTime( HIGH );         // 2.
-          if ( t < 12 )                        // specs say: 20us
+	        t = levelTime( HIGH );              // 2.
+          if ( t < 12 ) {                     // specs say: 20us
               return SimpleDHTErrDataRead;
-              //return (t == 0 ? 1234 : t);   // DEBUG
+          }
 	        data[ j ] = ( t > 40 ? 1 : 0 );     // specs: 26-28us -> 0, 70us -> 1
     }
 
     // DHT11 EOF:
     //    1. PULL LOW 50us.
-    t = levelTime( LOW );                // 1.
+    t = levelTime( LOW );                     // 1.
     if ( t < 35 ) {                           // specs say: 50us
         return SimpleDHTErrDataEOF;
-        //return (t == 0 ? 1234 : t);           // DEBUG
     }
 
     return SimpleDHTErrSuccess;

--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include "SimpleDHT.h"
-#include <limits.h>
 
 int SimpleDHT::read(byte* ptemperature, byte* phumidity, byte pdata[40]) {
     int ret = SimpleDHTErrSuccess;
@@ -87,10 +86,10 @@ int SimpleDHT::levelTime( byte level, int interval )
 
     time_end = micros();
 
-    if ( time_end < time_start )
-    {   // clock overflow (went back through 0)
-             time = time_end + ( ULONG_MAX - time_start );
-    } else { time = time_end - time_start; }
+    // for an unsigned int type, the difference have a correct value even if overflow
+    // (explanation here:
+    //     https://arduino.stackexchange.com/questions/33572/arduino-countdown-without-using-delay )
+    time = time_end - time_start;
 
     return time;
 }
@@ -110,10 +109,10 @@ int SimpleDHT::levelTimePrecise( byte level )
 
     time_end = micros();
 
-    if ( time_end < time_start )
-    {   // clock overflow (went back through 0)
-             time = time_end + ( ULONG_MAX - time_start );
-    } else { time = time_end - time_start; }
+    // for an unsigned int type, the difference have a correct value even if overflow
+    // (explanation here:
+    //     https://arduino.stackexchange.com/questions/33572/arduino-countdown-without-using-delay )
+    time = time_end - time_start;
 
     return time;
 }

--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -215,7 +215,7 @@ int SimpleDHT11::sample(byte data[40]) {
     }
 
     t = levelTime( HIGH );             // 2.
-    if ( t < 70 ) {                    // specs [2]: 80us
+    if ( t < 68 ) {                    // specs [2]: 80us
         return SimpleDHTErrStartHigh;
     }
 
@@ -227,7 +227,7 @@ int SimpleDHT11::sample(byte data[40]) {
     for (int j = 0; j < 40; j++)
     {
           t = levelTime( LOW, 10 );          // 1.
-          if ( t < 32 ) {                    // specs says: 50us
+          if ( t < 24 ) {                    // specs says: 50us
               return SimpleDHTErrDataLow;
           }
 
@@ -242,7 +242,7 @@ int SimpleDHT11::sample(byte data[40]) {
     // DHT11 EOF:
     //    1. PULL LOW 50us.
     t = levelTime( LOW );                     // 1.
-    if ( t < 35 ) {                           // specs say: 50us
+    if ( t < 24 ) {                           // specs say: 50us
         return SimpleDHTErrDataEOF;
     }
 

--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -68,7 +68,7 @@ int SimpleDHT::confirm(int us, byte level) {
 }
 
 
-int SimpleDHT::levelTime( byte level, int interval = 10 )
+int SimpleDHT::levelTime( byte level, int interval )
 {
     unsigned long time_start = micros(),
         time_end, time;

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -122,15 +122,15 @@ protected:
     // measure and return time (in microseconds)
     // with precision defined by interval between checking the state
     // while pin is in specified state (HIGH or LOW)
-    // @param pin      the DHT11 pin.
     // @param level    state which time is measured.
     // @param interval time interval between consecutive state checks.
+    // @return measured time (microseconds)
     virtual int levelTime(byte level, int interval = 10);
 
     // measure and return time (in microseconds)
     // while pin is in specified state (HIGH or LOW)
-    // @param pin   the DHT11 pin.
     // @param level state which time is measured
+    // @return measured time (microseconds)
     virtual int levelTimePrecise(byte level);
 
     // @data the bits of a byte.
@@ -138,7 +138,6 @@ protected:
     virtual byte bits2byte(byte data[8]);
 
     // read temperature and humidity from dht11.
-    // @param pin the pin for DHT11, for example, 2.
     // @param data a byte[40] to read bits to 5bytes.
     // @return 0 success; otherwise, error.
     // @remark please use simple_dht11_read().

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -46,6 +46,7 @@
 
 class SimpleDHT {
 protected:
+    static const unsigned long maxLevelTime = 10000000ul;   // 1s
     int pin = -1;
 
 #ifdef __AVR

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -57,6 +57,9 @@ protected:
 #endif
 
 public:
+
+    SimpleDHT(){}
+
     // @param pin the DHT11 pin.
     SimpleDHT( int pin ) {
         setPin( pin );
@@ -165,6 +168,8 @@ protected:
 */
 class SimpleDHT11 : public SimpleDHT {
 public:
+    SimpleDHT11() {}
+
     SimpleDHT11(int pin)
         : SimpleDHT (pin)
     {}
@@ -199,6 +204,7 @@ protected:
 */
 class SimpleDHT22 : public SimpleDHT {
 public:
+    SimpleDHT22() {}
     SimpleDHT22(int pin)
         : SimpleDHT (pin)
     {}

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2016-2017 winlin
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,7 +45,44 @@
 #define SimpleDHTErrZeroSamples 106
 
 class SimpleDHT {
+protected:
+    int pin = -1;
+
+#ifdef __AVR
+    // For direct GPIO access (8-bit AVRs only), store port and bitmask
+    // of the digital pin connected to the DHT.
+    // (other platforms use digitalRead(), do not need this)
+    uint8_t bitmask = 0xFF,
+            port    = 0xFF;
+#endif
+
 public:
+    // @param pin the DHT11 pin.
+    SimpleDHT( int pin ) {
+        setPin( pin );
+    };
+
+    // (eventually) change the pin configuration for existing instance
+    // @param pin the DHT11 pin.
+    void setPin( int pin ) {
+        this->pin = pin;
+#ifdef __AVR
+        // (only AVR) - set low level properties for configured pin
+        bitmask = digitalPinToBitMask( pin );
+        port    = digitalPinToPort( pin );
+#endif
+    }
+
+#ifdef __AVR
+    // only AVR - methods returning low level conf. of the pin
+
+    // @return bitmask to access pin state from port input register
+    int getBitmask() { return bitmask; }
+
+    // @return bitmask to access pin state from port input register
+    int getPort() { return port; }
+#endif
+
     // to read from dht11 or dht22.
     // @param pin the DHT11 pin.
     // @param ptemperature output, NULL to igore. In Celsius.
@@ -55,32 +92,58 @@ public:
     // @param pdata output 40bits sample, NULL to ignore.
     // @remark the min delay for this method is 1s(DHT11) or 2s(DHT22).
     // @return SimpleDHTErrSuccess is success; otherwise, failed.
-    virtual int read(int pin, byte* ptemperature, byte* phumidity, byte pdata[40]);
+    virtual int read(byte* ptemperature, byte* phumidity, byte pdata[40]);
+    virtual int read(int pin, byte* ptemperature, byte* phumidity, byte pdata[40])
+    {
+        setPin( pin );
+        read( ptemperature, phumidity, pdata );
+    }
+
     // to get a more accurate data.
     // @remark it's available for dht22. for dht11, it's the same of read().
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]) = 0;
     virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]) = 0;
+
 protected:
-    // confirm the OUTPUT is level in us, 
+    // confirm the OUTPUT is level in us,
     // for example, when DHT11 start sample, it will
     //    1. PULL LOW 80us, call confirm(pin, 80, LOW)
     //    2. PULL HIGH 80us, call confirm(pin, 80, HIGH)
     // @return 0 success; oterwise, error.
-    // @remark should never used to read bits, 
+    // @remark should never used to read bits,
     //    for function call use more time, maybe never got bit0.
     // @remark please use simple_dht11_read().
-    virtual int confirm(int pin, int us, byte level);
+    virtual int confirm(int us, byte level);
+
+    // measure and return time (in microseconds)
+    // with precision defined by interval between checking the state
+    // while pin is in specified state (HIGH or LOW)
+    // @param pin      the DHT11 pin.
+    // @param level    state which time is measured.
+    // @param interval time interval between consecutive state checks.
+    virtual int levelTime(byte level, int interval = 10);
+
+    // measure and return time (in microseconds)
+    // while pin is in specified state (HIGH or LOW)
+    // @param pin   the DHT11 pin.
+    // @param level state which time is measured
+    virtual int levelTimePrecise(byte level);
+
     // @data the bits of a byte.
     // @remark please use simple_dht11_read().
     virtual byte bits2byte(byte data[8]);
+
     // read temperature and humidity from dht11.
     // @param pin the pin for DHT11, for example, 2.
     // @param data a byte[40] to read bits to 5bytes.
     // @return 0 success; otherwise, error.
     // @remark please use simple_dht11_read().
-    virtual int sample(int pin, byte data[40]) = 0;
+    virtual int sample(byte data[40]) = 0;
+
     // parse the 40bits data to temperature and humidity.
     // @remark please use simple_dht11_read().
     virtual int parse(byte data[40], short* ptemperature, short* phumidity);
+
 };
 
 /*
@@ -102,9 +165,19 @@ protected:
 */
 class SimpleDHT11 : public SimpleDHT {
 public:
-    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]);
+    SimpleDHT11(int pin)
+        : SimpleDHT (pin)
+    {}
+
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]);
+    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40])
+    {
+        setPin( pin );
+        read2( ptemperature, phumidity, pdata );
+    }
+
 protected:
-    virtual int sample(int pin, byte data[40]);
+    virtual int sample(byte data[40]);
 };
 
 /*
@@ -126,9 +199,19 @@ protected:
 */
 class SimpleDHT22 : public SimpleDHT {
 public:
-    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]);
+    SimpleDHT22(int pin)
+        : SimpleDHT (pin)
+    {}
+
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]);
+    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40])
+    {
+        setPin( pin );
+        read2( ptemperature, phumidity, pdata );
+    }
+
 protected:
-    virtual int sample(int pin, byte data[40]);
+    virtual int sample(byte data[40]);
 };
 
 #endif


### PR DESCRIPTION
Changed 2 things for DHT11 :

* Timing in ``sample()`` and the way of measuring the time of expected pin state (level).
Note that this is very sensitive, different MCUs might need adjustments (as in the commit ca06c42). Eventually, if necessary, the MCU-specific thresholds could be stored.  Also, any change in ``levelTime()``, ``levelTimePrecise()`` might imply adjustments in time thresholds as with time measurements of this precision (microseconds) CPU time apparently matters...
(for DHT22 timing/sampling is _not_ changed and not tested!)

* Minor improvement in the class interface (with preserving the old way, so that all legacy code, examples etc. should work with no changes). This is also done for DHT22.

As you see, I was not using the ``confirm()``, which actually gives shorter code - but to make measurements when something fails, it was easier to have methods returning the measured time (``levelTime()``).

After these changes, the readings for the 2 mentioned boards are very stable with no errors (for me at least...).