### PR TITLE
Added support for using the internal pull-up resistor.

### DIFF
--- a/SimpleDHT.cpp
+++ b/SimpleDHT.cpp
@@ -60,6 +60,11 @@ int SimpleDHT::read(int pin, byte* ptemperature, byte* phumidity, byte pdata[40]
     return read(ptemperature, phumidity, pdata);
 }
 
+void SimpleDHT::setPinInputMode(uint8_t mode) {
+    if (mode != INPUT and mode != INPUT_PULLUP) mode = INPUT;
+    this->pinInputMode = mode;
+}
+
 void SimpleDHT::setPin(int pin) {
     this->pin = pin;
 #ifdef __AVR
@@ -196,7 +201,7 @@ int SimpleDHT11::sample(byte data[40]) {
     // notify DHT11 to start:
     //    1. PULL LOW 20ms.
     //    2. PULL HIGH 20-40us.
-    //    3. SET TO INPUT.
+    //    3. SET TO INPUT or INPUT_PULLUP.
     // Changes in timing done according to:
     //  [2] https://www.mouser.com/ds/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf
     // - original values specified in code
@@ -210,7 +215,7 @@ int SimpleDHT11::sample(byte data[40]) {
     // @see https://github.com/winlinvip/SimpleDHT/issues/4
     // @see https://github.com/winlinvip/SimpleDHT/pull/5
     digitalWrite(pin, HIGH);           // 2.
-    pinMode(pin, INPUT);
+    pinMode(pin, this->pinInputMode);
     delayMicroseconds(25);             // specs [2]: 20-40us
 
     // DHT11 starting:
@@ -305,7 +310,7 @@ int SimpleDHT22::sample(byte data[40]) {
     // notify DHT11 to start:
     //    1. T(be), PULL LOW 1ms(0.8-20ms).
     //    2. T(go), PULL HIGH 30us(20-200us), use 40us.
-    //    3. SET TO INPUT.
+    //    3. SET TO INPUT or INPUT_PULLUP.
     pinMode(pin, OUTPUT);
     digitalWrite(pin, LOW);
     delayMicroseconds(1000);
@@ -313,7 +318,7 @@ int SimpleDHT22::sample(byte data[40]) {
     // @see https://github.com/winlinvip/SimpleDHT/issues/4
     // @see https://github.com/winlinvip/SimpleDHT/pull/5
     digitalWrite(pin, HIGH);
-    pinMode(pin, INPUT);
+    pinMode(pin, this->pinInputMode);
     delayMicroseconds(40);
 
     // DHT11 starting:

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -57,6 +57,7 @@ class SimpleDHT {
 protected:
     long levelTimeout = 5000000; // 500ms
     int pin = -1;
+    uint8_t pinInputMode = INPUT;
 #ifdef __AVR
     // For direct GPIO access (8-bit AVRs only), store port and bitmask
     // of the digital pin connected to the DHT.
@@ -67,6 +68,12 @@ protected:
 public:
     SimpleDHT();
     SimpleDHT(int pin);
+public:
+    // set the input mode of the pin from INPUT and INPUT_PULLUP
+    // to permit the use of the internal pullup resistor for
+    // for bare modules
+    // @param mode the pin input mode.
+    void setPinInputMode(uint8_t mode = INPUT);
 public:
     // to read from dht11 or dht22.
     // @param pin the DHT11 pin.


### PR DESCRIPTION
Choose the input mode of the pin from INPUT and INPUT_PULLUP to permit the use of the internal pull-up resistor for for bare DHT modules.