### PR TITLE
Improved Memory usage by utilizing bytes properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Debug files
 *.dSYM/
+
+# Visual Studio cache/options directory
+.vs/

--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -87,12 +87,12 @@ public:
     // @param pdata output 40bits sample, NULL to ignore.
     // @remark the min delay for this method is 1s(DHT11) or 2s(DHT22).
     // @return SimpleDHTErrSuccess is success; otherwise, failed.
-    virtual int read(byte* ptemperature, byte* phumidity, byte pdata[40]);
-    virtual int read(int pin, byte* ptemperature, byte* phumidity, byte pdata[40]);
+    virtual int read(byte* ptemperature, byte* phumidity, byte pdata[5]);
+    virtual int read(int pin, byte* ptemperature, byte* phumidity, byte pdata[5]);
     // To get a more accurate data.
     // @remark it's available for dht22. for dht11, it's the same of read().
-    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]) = 0;
-    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]) = 0;
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[5]) = 0;
+    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[5]) = 0;
 protected:
     // To (eventually) change the pin configuration for existing instance
     // @param pin The DHT11 pin.
@@ -112,17 +112,17 @@ protected:
     // @param interval time interval between consecutive state checks.
     // @return measured time (microseconds). -1 if timeout.
     virtual long levelTime(byte level, int firstWait = 10, int interval = 6);
-    // @data the bits of a byte.
+    // @data reverses a byte with reversed data
     // @remark please use simple_dht11_read().
-    virtual byte bits2byte(byte data[8]);
+    virtual byte reverse(byte data);
     // read temperature and humidity from dht11.
     // @param data a byte[40] to read bits to 5bytes.
     // @return 0 success; otherwise, error.
     // @remark please use simple_dht11_read().
-    virtual int sample(byte data[40]) = 0;
+    virtual int sample(byte data[5]) = 0;
     // parse the 40bits data to temperature and humidity.
     // @remark please use simple_dht11_read().
-    virtual int parse(byte data[40], short* ptemperature, short* phumidity);
+    virtual int parse(byte data[5], short* ptemperature, short* phumidity);
 };
 
 /*
@@ -147,10 +147,10 @@ public:
     SimpleDHT11();
     SimpleDHT11(int pin);
 public:
-    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]);
-    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]);
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[5]);
+    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[5]);
 protected:
-    virtual int sample(byte data[40]);
+    virtual int sample(byte data[5]);
 };
 
 /*
@@ -175,10 +175,10 @@ public:
     SimpleDHT22();
     SimpleDHT22(int pin);
 public:
-    virtual int read2(float* ptemperature, float* phumidity, byte pdata[40]);
-    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[40]);
+    virtual int read2(float* ptemperature, float* phumidity, byte pdata[5]);
+    virtual int read2(int pin, float* ptemperature, float* phumidity, byte pdata[5]);
 protected:
-    virtual int sample(byte data[40]);
+    virtual int sample(byte data[5]);
 };
 
 #endif

--- a/examples/DHT11WithRawBits/DHT11WithRawBits.ino
+++ b/examples/DHT11WithRawBits/DHT11WithRawBits.ino
@@ -19,7 +19,7 @@ void loop() {
   // read with raw sample data.
   byte temperature = 0;
   byte humidity = 0;
-  byte data[40] = {0};
+  byte data[5] = {0};
   int err = SimpleDHTErrSuccess;
   if ((err = dht11.read(&temperature, &humidity, data)) != SimpleDHTErrSuccess) {
     Serial.print("Read DHT11 failed, err="); Serial.println(err);delay(1000);
@@ -27,11 +27,10 @@ void loop() {
   }
   
   Serial.print("Sample RAW Bits: ");
-  for (int i = 0; i < 40; i++) {
-    Serial.print((int)data[i]);
-    if (i > 0 && ((i + 1) % 4) == 0) {
-      Serial.print(' ');
-    }
+  for (int i = 0; i < 5; i++) {
+    for(int n=0;n<8;n++)
+      Serial.print(bitRead(data[i],n));   
+    Serial.print(' ');
   }
   Serial.println("");
   

--- a/examples/DHT22WithRawBits/DHT22WithRawBits.ino
+++ b/examples/DHT22WithRawBits/DHT22WithRawBits.ino
@@ -21,7 +21,7 @@ void loop() {
   //    if user doesn't care about the accurate data, use read to get a byte data, such as 10*C.
   float temperature = 0;
   float humidity = 0;
-  byte data[40] = {0};
+  byte data[5] = {0};
   int err = SimpleDHTErrSuccess;
   if ((err = dht22.read2(&temperature, &humidity, data)) != SimpleDHTErrSuccess) {
     Serial.print("Read DHT22 failed, err="); Serial.println(err);delay(2000);
@@ -29,11 +29,10 @@ void loop() {
   }
   
   Serial.print("Sample RAW Bits: ");
-  for (int i = 0; i < 40; i++) {
-    Serial.print((int)data[i]);
-    if (i > 0 && ((i + 1) % 4) == 0) {
+  for (int i = 0; i < 5; i++) {
+      for (int n = 0; n < 8; n++)
+          Serial.print(bitRead(data[i], n));
       Serial.print(' ');
-    }
   }
   Serial.println("");
   


### PR DESCRIPTION
In it's current state the Library uses 40 bytes to store 40 bits, which is a huge waste of memory on a restricted system. Therefore I propose a system where bytes are utilized not as booleans, but as 8bit containers. Using the bitWrite function and some math, this change will reduce the memory footprint to 5 bytes, while retaining all functionality. Furthermore this improves things like the parse function, where indices can now be used instead of pointer arithmetic. 
I have fixed all examples to work with this change.