### PR TITLE
Fix typo; 5s -> 500ms

### DIFF
--- a/SimpleDHT.h
+++ b/SimpleDHT.h
@@ -57,7 +57,7 @@
 
 class SimpleDHT {
 protected:
-    long levelTimeout = 5000000; // 500ms
+    long levelTimeout = 500000; // 500ms
     int pin = -1;
     uint8_t pinInputMode = INPUT;
 #ifdef __AVR


### PR DESCRIPTION
Lowered the value of timeout to 500ms (should be enough) in order to match the comment. Fixes #43.